### PR TITLE
debian: Fix directory layout

### DIFF
--- a/debian/libhydrasdr-dev.install
+++ b/debian/libhydrasdr-dev.install
@@ -1,4 +1,4 @@
 usr/include/*
-usr/lib/lib*.a
-usr/lib/lib*.so
-usr/lib/pkgconfig/*
+usr/lib/*/lib*.a
+usr/lib/*/lib*.so
+usr/lib/*/pkgconfig/*

--- a/debian/libhydrasdr0.install
+++ b/debian/libhydrasdr0.install
@@ -1,1 +1,1 @@
-usr/lib/lib*.so.*
+usr/lib/*/lib*.so.*


### PR DESCRIPTION
Contemporary debian releases install libraries and pkgconfig files into architecture tripplet subdirectories, fix this, otherwise `$ dpkg-buildpackage -b -us -uc -j$(nproc)` fails with:

```
   dh_install
dh_install: warning: Cannot find (any matches for) "usr/lib/lib*.a" (tried in ., debian/tmp)

dh_install: warning: libhydrasdr-dev missing files: usr/lib/lib*.a
dh_install: warning: Cannot find (any matches for) "usr/lib/lib*.so" (tried in ., debian/tmp)

dh_install: warning: libhydrasdr-dev missing files: usr/lib/lib*.so
dh_install: warning: Cannot find (any matches for) "usr/lib/pkgconfig/*" (tried in ., debian/tmp)

dh_install: warning: libhydrasdr-dev missing files: usr/lib/pkgconfig/*
dh_install: warning: Cannot find (any matches for) "usr/lib/lib*.so.*" (tried in ., debian/tmp)

dh_install: warning: libhydrasdr0 missing files: usr/lib/lib*.so.* dh_install: error: missing files, aborting
make: *** [debian/rules:4: binary] Error 255
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
```